### PR TITLE
[Sikkerhet] Oppretter sikkerhetsmappa med beskrivelse.yaml (v2.0) og legger til Security Champion i CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.sikkerhet/ @omaen

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,0 +1,5 @@
+version: 2.0
+organization: IT
+product: Backstage
+repo_types: [[Library]]
+platforms: [[]]

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,5 +1,5 @@
 version: 2.0
 organization: IT
 product: Backstage
-repo_types: [[Library]]
-platforms: [[]]
+repo_types: [Library]
+platforms: []


### PR DESCRIPTION
## Kort forklart
Denne PRen oppretter filen `.sikkerhet/beskrivelse.yaml`, og `.github\CODEOWNERS` dersom `CODEOWNERS` ikke allerede finnes

I `CODEOWNERS` legges det til linjen `/.sikkerhet/ @omaen`, der `omaen` er GitHub-brukernavnet til den som skal være teamets kontaktperson om sikkerhet ([Security Champion](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732332108/Security+Champion)).

I `/.sikkerhet/beskrivelse.yaml` legges følgende felter legges inn:

- `version: 2.0`
- `organization: IT`
- `product: Backstage`
- `repo_types: [[Library]]`
- `platforms: [[]]`

## Litt lenger forklart (hvorfor gjør vi dette?)
Det er beskrevet [her i Sikkehertshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet).